### PR TITLE
解凍処理のフェーズ化

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,39 +142,17 @@ public/images/
 ├─ kenney_city-kit-commercial_20.zip
 └─ kenney_roguelike-modern-city.zip
 ```
-サイズが大きいため、5 段階に分けて解凍するスクリプトを用意しています。
+サイズが大きいため、2 段階に分けて解凍するスクリプトを用意しています。
 
-まずは以下のコマンドでステップ 1 を実行し、ライセンスファイルのみを展開します。
+以下のコマンドを順に実行してください。
 
 ```bash
-bash scripts/unpack_step1.sh
-```
+# フェーズ1: ライセンスと主要画像を展開
+bash scripts/unpack_phase1.sh
 
-続けてステップ 2 〜 5 を順に実行してください。
-
-#### ステップ 2：主要画像の展開
-```bash
-bash scripts/unpack_step2.sh
+# フェーズ2: 残り素材を展開しZIPを削除
+bash scripts/unpack_phase2.sh
 ```
-`Tilemap/` や `Tiles/`、city-kit の基本 PNG が `images/` 以下に展開されます。
-
-#### ステップ 3：オプション素材の展開
-```bash
-bash scripts/unpack_step3.sh
-```
-残りの 3D モデルやテキストファイルが展開されます。
-
-#### ステップ 4：不要ファイルの削除
-```bash
-bash scripts/unpack_step4.sh
-```
-`Sample.png` や `Preview*.png`、`.url` ファイルを削除して整理します。
-
-#### ステップ 5：ZIP の削除（任意）
-```bash
-bash scripts/unpack_step5.sh
-```
-アーカイブを削除してディスク容量を節約します。
 
 展開後、`public/tileManifest.js` で各画像を参照できるようになります。
 

--- a/scripts/unpack_phase1.sh
+++ b/scripts/unpack_phase1.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# phase1: ライセンスと主要画像を展開するスクリプト
+set -e
+
+# --- ライセンスファイルの展開 ---
+# city-kit のライセンスファイルを解凍
+unzip -o public/images/kenney_city-kit-commercial_20.zip License.txt -d public/images/city-kit
+# roguelike のライセンスファイルを解凍
+unzip -o public/images/kenney_roguelike-modern-city.zip License.txt -d public/images/roguelike
+
+# --- 主要画像の展開 ---
+# roguelike の主要画像 (Tiles ディレクトリの PNG) をパスを除いて展開
+unzip -o -j public/images/kenney_roguelike-modern-city.zip "Tiles/*.png" -d public/images/roguelike
+# city-kit の主な PNG ファイルを階層を無視して展開
+unzip -o -j public/images/kenney_city-kit-commercial_20.zip "Previews/*.png" "Preview*.png" "Models/Textures/*.png" -d public/images/city-kit
+
+echo "phase1: ライセンスと主要画像を展開しました"

--- a/scripts/unpack_phase2.sh
+++ b/scripts/unpack_phase2.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# phase2: 残り素材を展開しZIPを削除するスクリプト
+set -e
+
+# --- オプション素材の展開 ---
+# roguelike の残りファイル（Tilemap/Tiles, License.txt を除く）を展開
+unzip -o -j public/images/kenney_roguelike-modern-city.zip -x "Tilemap/*" "Tiles/*" "License.txt" -d public/images/roguelike
+# city-kit の残りファイル（主要PNGとライセンスを除く）を展開
+unzip -o -j public/images/kenney_city-kit-commercial_20.zip -x "Previews/*" "Preview*.png" "Models/Textures/*" "License.txt" -d public/images/city-kit
+
+# --- 不要ファイルの削除 ---
+find public/images -type f -name 'Sample.png' -delete
+find public/images -type f -name 'Preview*.png' -delete
+find public/images -type f -name '*.url' -delete
+
+# --- ZIP アーカイブの削除 ---
+rm -f public/images/kenney_city-kit-commercial_20.zip
+rm -f public/images/kenney_roguelike-modern-city.zip
+
+echo "phase2: 残り素材を展開しZIPを削除しました"


### PR DESCRIPTION
## 概要
- 5 つに分かれていた解凍スクリプトをフェーズ1・2に統合
- README の解凍手順を更新
- 新しいスクリプトに実行権限を付与

## 動作確認
- `npm test` で全テストが成功することを確認


------
https://chatgpt.com/codex/tasks/task_e_685dded8e294832c9abc921192e3f489