### PR TITLE
ゲーム画面のマップ構築に素材を利用

### DIFF
--- a/public/game_screen.html
+++ b/public/game_screen.html
@@ -37,7 +37,8 @@
     </div>
   </header>
   <!-- マップ表示用キャンバス -->
-  <canvas id="mapCanvas" class="flex-grow w-full bg-black"></canvas>
+  <!-- 背景色は薄いグレーにしてマップを見やすくする -->
+  <canvas id="mapCanvas" class="flex-grow w-full bg-gray-200"></canvas>
   <!-- ドロワー用のオーバーレイ -->
   <div id="drawerOverlay" class="fixed inset-0 bg-black/30"></div>
   <!-- サイドドロワー -->

--- a/public/map_canvas.js
+++ b/public/map_canvas.js
@@ -3,16 +3,16 @@
   let TILE_SIZE = 32;
   // もとの10x10マップ
   const baseMap = [
-    ['grass', 'grass', 'grass', 'grass', 'grass', 'grass', 'grass', 'grass', 'grass', 'grass'],
-    ['grass', 'road_horizontal', 'road_horizontal', 'road_horizontal', 'road_horizontal', 'road_horizontal', 'road_horizontal', 'road_horizontal', 'road_horizontal', 'grass'],
-    ['grass', 'road_horizontal', 'building_wall', 'building_wall', 'building_wall', 'building_wall', 'building_wall', 'building_wall', 'road_horizontal', 'grass'],
-    ['grass', 'road_horizontal', 'building_bg', 'building_bg', 'building_bg', 'building_bg', 'building_bg', 'building_bg', 'road_horizontal', 'grass'],
-    ['grass', 'road_horizontal', 'building_bg', 'tree', 'tree', 'tree', 'tree', 'building_bg', 'road_horizontal', 'grass'],
-    ['grass', 'road_horizontal', 'building_bg', 'tree', 'character_01', 'car_blue', 'tree', 'building_bg', 'road_horizontal', 'grass'],
-    ['grass', 'road_horizontal', 'building_bg', 'tree', 'tree', 'tree', 'tree', 'building_bg', 'road_horizontal', 'grass'],
-    ['grass', 'road_horizontal', 'building_bg', 'building_bg', 'building_bg', 'building_bg', 'building_bg', 'building_bg', 'road_horizontal', 'grass'],
-    ['grass', 'road_horizontal', 'road_horizontal', 'road_horizontal', 'pedestrian_crossing', 'road_horizontal', 'road_horizontal', 'road_horizontal', 'road_horizontal', 'grass'],
-    ['grass', 'grass', 'grass', 'grass', 'grass', 'grass', 'grass', 'grass', 'grass', 'grass'],
+    ['grass','grass','grass','grass','grass','grass','grass','grass','grass','grass'],
+    ['grass','road_horizontal','road_horizontal','road_horizontal','road_horizontal','road_horizontal','road_horizontal','road_horizontal','road_horizontal','grass'],
+    ['grass','road_horizontal','building_wall','building_wall','building_wall','building_wall','building_wall','building_wall','road_horizontal','grass'],
+    ['grass','road_horizontal','building-a','building-b','building-c','building-d','building-e','building-f','road_horizontal','grass'],
+    ['grass','road_horizontal','building-g','grass','grass','grass','grass','building-h','road_horizontal','grass'],
+    ['grass','road_horizontal','building-i','grass','grass','grass','grass','building-j','road_horizontal','grass'],
+    ['grass','road_horizontal','building-k','grass','grass','grass','grass','building-l','road_horizontal','grass'],
+    ['grass','road_horizontal','building-m','building-n','building-n','building-n','building-n','building-n','road_horizontal','grass'],
+    ['grass','road_horizontal','road_horizontal','road_horizontal','pedestrian_crossing','road_horizontal','road_horizontal','road_horizontal','road_horizontal','grass'],
+    ['grass','grass','grass','grass','grass','grass','grass','grass','grass','grass'],
   ];
 
   // baseMap を2倍に拡大して20x20のマップを作成
@@ -37,7 +37,13 @@
 
   // --- 通行不可マップの作成 ------------------------------
   // 当たり判定に備え、通行できないタイルを true とする
-  const blockedTiles = ['building_wall', 'building_bg', 'tree', 'car_blue'];
+  const blockedTiles = [
+    'building_wall',
+    'building-a', 'building-b', 'building-c', 'building-d',
+    'building-e', 'building-f', 'building-g', 'building-h',
+    'building-i', 'building-j', 'building-k', 'building-l',
+    'building-m', 'building-n'
+  ];
   const obstacleMap = mapData.map(row => row.map(tile => blockedTiles.includes(tile)));
 
   // --- プレイヤー移動処理 --------------------------------

--- a/public/tileManifest.js
+++ b/public/tileManifest.js
@@ -3,19 +3,30 @@
 // 画像ファイルは images フォルダ以下に展開してください
 
 const tileManifest = {
-  // Roguelike素材
-  asphalt: "/images/roguelike/tile_0001.png",
-  road_horizontal: "/images/roguelike/tile_0012.png",
-  building_wall: "/images/roguelike/tile_0025.png",
-  grass: "/images/roguelike/tile_0033.png",
-  pedestrian_crossing: "/images/roguelike/tile_0040.png",
+  // material フォルダ (番号付きタイル)
+  asphalt: "/images/material/Tiles/tile_0001.png",
+  road_horizontal: "/images/material/Tiles/tile_0012.png",
+  building_wall: "/images/material/Tiles/tile_0025.png",
+  grass: "/images/material/Tiles/tile_0033.png",
+  pedestrian_crossing: "/images/material/Tiles/tile_0040.png",
 
-  // City-kit素材（アイソメ）
-  building_bg: "/images/city-kit/Building_Background.png",
-  road_straight: "/images/city-kit/Road_Straight.png",
-  tree: "/images/city-kit/Tree_01.png",
-  car_blue: "/images/city-kit/Car_Blue.png",
-  character_01: "/images/city-kit/People_01.png",
+  // material2 フォルダ (建物プレビュー画像)
+  'building-a': "/images/material2/Previews/building-a.png",
+  'building-b': "/images/material2/Previews/building-b.png",
+  'building-c': "/images/material2/Previews/building-c.png",
+  'building-d': "/images/material2/Previews/building-d.png",
+  'building-e': "/images/material2/Previews/building-e.png",
+  'building-f': "/images/material2/Previews/building-f.png",
+  'building-g': "/images/material2/Previews/building-g.png",
+  'building-h': "/images/material2/Previews/building-h.png",
+  'building-i': "/images/material2/Previews/building-i.png",
+  'building-j': "/images/material2/Previews/building-j.png",
+  'building-k': "/images/material2/Previews/building-k.png",
+  'building-l': "/images/material2/Previews/building-l.png",
+  'building-m': "/images/material2/Previews/building-m.png",
+  'building-n': "/images/material2/Previews/building-n.png",
+  // プレイヤー用の小物画像
+  character_01: "/images/material2/Previews/detail-parasol-a.png",
 };
 
 // CommonJS エクスポート


### PR DESCRIPTION
## 変更点
- `tileManifest.js` を更新し、`public/images/material` と `material2` から画像を読み込むように修正
- `map_canvas.js` の初期マップを建物画像中心の構成に変更
- 通行不可タイルを建物名ベースに更新
- `game_screen.html` のキャンバス背景色を薄いグレーへ変更

## テスト結果
- `npm test` は `jest: not found` のため実行できず


------
https://chatgpt.com/codex/tasks/task_e_685df941ca5c832c9193a0f6fdd6d768