### PR TITLE
マップタイル読み込み不具合の修正

### DIFF
--- a/public/tileManifest.js
+++ b/public/tileManifest.js
@@ -4,29 +4,31 @@
 
 const tileManifest = {
   // material フォルダ (番号付きタイル)
-  asphalt: "/images/material/Tiles/tile_0001.png",
-  road_horizontal: "/images/material/Tiles/tile_0012.png",
-  building_wall: "/images/material/Tiles/tile_0025.png",
-  grass: "/images/material/Tiles/tile_0033.png",
-  pedestrian_crossing: "/images/material/Tiles/tile_0040.png",
+  // 先頭のスラッシュを付けない相対パスに変更
+  // こうすることで、file:// で開いた場合でも画像を正しく読み込めます
+  asphalt: "images/material/Tiles/tile_0001.png",
+  road_horizontal: "images/material/Tiles/tile_0012.png",
+  building_wall: "images/material/Tiles/tile_0025.png",
+  grass: "images/material/Tiles/tile_0033.png",
+  pedestrian_crossing: "images/material/Tiles/tile_0040.png",
 
   // material2 フォルダ (建物プレビュー画像)
-  'building-a': "/images/material2/Previews/building-a.png",
-  'building-b': "/images/material2/Previews/building-b.png",
-  'building-c': "/images/material2/Previews/building-c.png",
-  'building-d': "/images/material2/Previews/building-d.png",
-  'building-e': "/images/material2/Previews/building-e.png",
-  'building-f': "/images/material2/Previews/building-f.png",
-  'building-g': "/images/material2/Previews/building-g.png",
-  'building-h': "/images/material2/Previews/building-h.png",
-  'building-i': "/images/material2/Previews/building-i.png",
-  'building-j': "/images/material2/Previews/building-j.png",
-  'building-k': "/images/material2/Previews/building-k.png",
-  'building-l': "/images/material2/Previews/building-l.png",
-  'building-m': "/images/material2/Previews/building-m.png",
-  'building-n': "/images/material2/Previews/building-n.png",
+  'building-a': "images/material2/Previews/building-a.png",
+  'building-b': "images/material2/Previews/building-b.png",
+  'building-c': "images/material2/Previews/building-c.png",
+  'building-d': "images/material2/Previews/building-d.png",
+  'building-e': "images/material2/Previews/building-e.png",
+  'building-f': "images/material2/Previews/building-f.png",
+  'building-g': "images/material2/Previews/building-g.png",
+  'building-h': "images/material2/Previews/building-h.png",
+  'building-i': "images/material2/Previews/building-i.png",
+  'building-j': "images/material2/Previews/building-j.png",
+  'building-k': "images/material2/Previews/building-k.png",
+  'building-l': "images/material2/Previews/building-l.png",
+  'building-m': "images/material2/Previews/building-m.png",
+  'building-n': "images/material2/Previews/building-n.png",
   // プレイヤー用の小物画像
-  character_01: "/images/material2/Previews/detail-parasol-a.png",
+  character_01: "images/material2/Previews/detail-parasol-a.png",
 };
 
 // CommonJS エクスポート


### PR DESCRIPTION
## 変更内容
- `public/tileManifest.js` 内の画像パスを相対パスへ変更
  - `file://` で開いた際に画像が読み込めずマップが黒くなる問題を解消
- 画像読み込み失敗を防ぐためのコメントを追加

## 動作確認
- `npm test` を実行し、全テストが成功することを確認済み


------
https://chatgpt.com/codex/tasks/task_e_685dfc7ca328832c8de263ba79abea08