### PR TITLE
マップ表示の初期化タイミングを修正

### DIFF
--- a/public/components/GameScreen.js
+++ b/public/components/GameScreen.js
@@ -117,6 +117,16 @@
     localStorage.setItem('notifications', JSON.stringify(messages));
   }, [messages]);
 
+  // -----------------------------
+  // マップCanvasの初期化
+  // -----------------------------
+  // React で GameScreen が描画された後に呼び出します
+  useEffect(() => {
+    if (typeof initMapCanvas === 'function') {
+      initMapCanvas();
+    }
+  }, []);
+
   // カード表示用のラベルと説明。
   // desc には HTML 文字列を渡し、指標の概要と簡単な影響を文章で示します
 

--- a/public/game_screen_react.js
+++ b/public/game_screen_react.js
@@ -69,10 +69,6 @@
     ReactDOM.createRoot(document.getElementById('root')).render(
       React.createElement(GameScreen)
     );
-    // マップCanvasの初期化も行う
-    if (typeof initMapCanvas === 'function') {
-      initMapCanvas();
-    }
   });
 
   // ブラウザからも参照できるようグローバルに登録


### PR DESCRIPTION
## 概要
React 版ゲーム画面で `initMapCanvas()` が早すぎるタイミングで実行され、キャンバスが存在せずマップが表示されない問題を修正しました。

## 変更点
- `GameScreen` コンポーネントでマウント後にマップ初期化処理を呼び出す `useEffect` を追加
- `game_screen_react.js` から `initMapCanvas()` 呼び出しを削除

## テスト
- `npm install`
- `npm test` で全テストが成功することを確認


------
https://chatgpt.com/codex/tasks/task_e_685e25848858832c8d6d92b04ed4c02c