### PR TITLE
キャラクター初期位置と広場を調整

### DIFF
--- a/public/map_canvas.js
+++ b/public/map_canvas.js
@@ -5,6 +5,12 @@
   const baseMap = Array.from({ length: 10 }, (_, y) =>
     Array.from({ length: 10 }, (_, x) => (x === 5 || y === 5 ? 'road_horizontal' : 'grass'))
   );
+  // プレイヤー初期位置周辺は広場としてアスファルトに変更
+  for (let y = 4; y <= 6; y++) {
+    for (let x = 4; x <= 6; x++) {
+      baseMap[y][x] = 'asphalt';
+    }
+  }
 
   // baseMap を20倍に拡大して 200×200 のマップを作成
   const SCALE = 20;
@@ -155,7 +161,8 @@
     // キャンバス幅からタイル1枚のサイズを計算
     TILE_SIZE = canvas.width / mapData[0].length;
     // プレイヤーの初期座標もタイルサイズに合わせて設定
-    player.x = 4 * TILE_SIZE;
+    // 十字路の中央に配置する
+    player.x = 5 * TILE_SIZE;
     player.y = 5 * TILE_SIZE;
 
     const usedKeys = [...new Set(mapData.flat().concat('character_01'))];

--- a/public/tileManifest.js
+++ b/public/tileManifest.js
@@ -27,8 +27,9 @@ const tileManifest = {
   'building-l': "images/material2/Previews/building-l.png",
   'building-m': "images/material2/Previews/building-m.png",
   'building-n': "images/material2/Previews/building-n.png",
-  // プレイヤー用の小物画像
-  character_01: "images/material2/Previews/detail-parasol-a.png",
+  // プレイヤーキャラクター画像
+  // roguelike 素材に含まれる人型タイルを利用する
+  character_01: "images/roguelike/tile_0156.png",
 };
 
 // CommonJS エクスポート


### PR DESCRIPTION
## 変更点
- タイルマニフェストでプレイヤー画像を roguelike 素材へ変更
- `map_canvas.js` で初期位置周辺を広場化し、中央にキャラクターを配置

## テスト結果
- `npm test` がすべて成功することを確認


------
https://chatgpt.com/codex/tasks/task_e_685e43219ec8832c89a3ddf2207ae522