### PR TITLE
スプライト情報の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,25 @@ images/
 | `building-d.png` | 建物D | マップ用建物 |
 | `detail-parasol-a.png` | 傘付きパラソル | キャラクター装飾 |
 
+### spriteInfo.js について
+
+`public/spriteInfo.js` には各スプライトの日本語説明をまとめています。キーは `tileManifest.js` と同じ名前を使っているため、マップ生成時に参照できます。
+
+```javascript
+// 例
+const spriteInfo = {
+  asphalt: { file: 'images/sprites/tile_0001.png', desc: 'アスファルト舗装' }
+};
+```
+
+新しい画像を追加した場合は以下の手順で登録してください。
+
+1. `public/images/sprites` に画像を配置し、`tileManifest.js` にパスを追記します。
+2. 同じキーを `spriteInfo.js` に追加し、`desc` に短い説明を書きます。
+3. `game_screen.html` などで `spriteInfo.js` が読み込まれているか確認します。
+
+これにより、マップ生成時に使用タイルの一覧がコンソールへ表示され、選択ミスを防げます。
+
 
 ---
 

--- a/public/game_screen.html
+++ b/public/game_screen.html
@@ -86,6 +86,7 @@
   </div>
   <!-- マップ描画に必要なスクリプト -->
   <script src="tileManifest.js"></script>
+  <script src="spriteInfo.js"></script>
   <script src="map_canvas.js"></script>
   <!-- ゲーム用スクリプトを読み込み -->
   <script src="game_screen.js"></script>

--- a/public/game_screen_react.html
+++ b/public/game_screen_react.html
@@ -24,6 +24,7 @@
   <script defer src="components/GameScreen.js"></script>
   <!-- マップ表示用スクリプト -->
   <script defer src="tileManifest.js"></script>
+  <script defer src="spriteInfo.js"></script>
   <script defer src="map_canvas.js"></script>
   <!-- React版スクリプト読み込み -->
   <script defer src="game_screen_react.js"></script>

--- a/public/map_canvas.js
+++ b/public/map_canvas.js
@@ -97,6 +97,10 @@
     keys.forEach(key => {
       const img = new Image();
       img.src = manifest[key];
+      // spriteInfo があれば説明を紐付けておく
+      if (typeof spriteInfo !== 'undefined' && spriteInfo[key]) {
+        img.desc = spriteInfo[key].desc;
+      }
 
       // 読み込みが完了した場合
       img.onload = () => {
@@ -150,6 +154,7 @@
 
   function initMapCanvas() {
     const canvas = document.getElementById('mapCanvas');
+    // 必要なデータがなければ処理しない
     if (!canvas || typeof tileManifest === 'undefined') {
       return;
     }
@@ -167,13 +172,23 @@
 
     const usedKeys = [...new Set(mapData.flat().concat('character_01'))];
     const manifest = {};
-    usedKeys.forEach(k => { if (tileManifest[k]) manifest[k] = tileManifest[k]; });
+    const descriptions = {};
+    usedKeys.forEach(k => {
+      if (tileManifest[k]) {
+        manifest[k] = tileManifest[k];
+        // spriteInfo があれば説明も取得
+        if (typeof spriteInfo !== 'undefined' && spriteInfo[k]) {
+          descriptions[k] = spriteInfo[k].desc;
+        }
+      }
+    });
 
-    const state = { canvas, ctx, images: null };
+    const state = { canvas, ctx, images: null, descriptions };
 
     loadImages(manifest, (images) => {
       state.images = images;
       drawMap(canvas, ctx, images);
+      console.log('使用タイル情報', descriptions);
     });
 
     // キー入力でプレイヤーを移動

--- a/public/spriteInfo.js
+++ b/public/spriteInfo.js
@@ -1,0 +1,42 @@
+// spriteInfo.js
+// 各スプライト画像の簡易説明を保持するデータベース
+// キーは tileManifest.js で利用している名前と揃えています
+// 必要に応じて description を日本語で追加してください
+
+const spriteInfo = {
+  // 基本タイル
+  asphalt: { file: 'images/sprites/tile_0001.png', desc: 'アスファルト舗装' },
+  road_horizontal: { file: 'images/sprites/tile_0012.png', desc: '横向き道路' },
+  building_wall: { file: 'images/sprites/tile_0025.png', desc: '建物の壁' },
+  grass: { file: 'images/sprites/tile_0033.png', desc: '芝生タイル' },
+  pedestrian_crossing: { file: 'images/sprites/tile_0040.png', desc: '横断歩道' },
+
+  // 建物プレビュー
+  'building-a': { file: 'images/sprites/building-a.png', desc: '低層ビルA' },
+  'building-b': { file: 'images/sprites/building-b.png', desc: '低層ビルB' },
+  'building-c': { file: 'images/sprites/building-c.png', desc: '低層ビルC' },
+  'building-d': { file: 'images/sprites/building-d.png', desc: '低層ビルD' },
+  'building-e': { file: 'images/sprites/building-e.png', desc: '低層ビルE' },
+  'building-f': { file: 'images/sprites/building-f.png', desc: '低層ビルF' },
+  'building-g': { file: 'images/sprites/building-g.png', desc: '低層ビルG' },
+  'building-h': { file: 'images/sprites/building-h.png', desc: '低層ビルH' },
+  'building-i': { file: 'images/sprites/building-i.png', desc: '低層ビルI' },
+  'building-j': { file: 'images/sprites/building-j.png', desc: '低層ビルJ' },
+  'building-k': { file: 'images/sprites/building-k.png', desc: '低層ビルK' },
+  'building-l': { file: 'images/sprites/building-l.png', desc: '低層ビルL' },
+  'building-m': { file: 'images/sprites/building-m.png', desc: '低層ビルM' },
+  'building-n': { file: 'images/sprites/building-n.png', desc: '低層ビルN' },
+
+  // プレイヤーキャラクター
+  character_01: { file: 'images/roguelike/tile_0156.png', desc: 'キャラクター1' },
+};
+
+// Node.js 用エクスポート
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { spriteInfo };
+}
+
+// ブラウザ用グローバル変数
+if (typeof window !== 'undefined') {
+  window.spriteInfo = spriteInfo;
+}


### PR DESCRIPTION
## 変更内容
- `public/spriteInfo.js` を新規追加し、タイル画像と日本語説明を管理
- `map_canvas.js` で `spriteInfo` を読み込み、ロード時に説明を紐付け
- ゲーム画面 HTML で `spriteInfo.js` を読み込むよう更新
- 使用タイル一覧をコンソールに表示し、デバッグしやすくした
- `README.md` に `spriteInfo.js` の使い方・拡張方法を追記

## 確認事項
- `npm test` で既存テストがすべて成功することを確認

------
https://chatgpt.com/codex/tasks/task_e_686002623c34832cbbb18f0857fd9d3e