### PR TITLE
Kenneyライセンス情報追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ npm test     # Jest でテストを実行
 ## 🌆 都市マップ素材
 
 ゲーム内マップで利用する画像パーツは Kenney 氏の素材を使用します。
+これらは **CC0 ライセンス** で公開されており、公式サイト [Kenney](https://www.kenney.nl/) から入手できます。
+ライセンス文書は `public/images/city-kit/License.txt` など各フォルダに配置してあるので、詳細はそちらをご覧ください。
 `public/images/` フォルダーには以下の ZIP ファイルを配置しており、
 スクリプト実行後に `sprites` ディレクトリへ展開されます。
 


### PR DESCRIPTION
## 変更内容
- README の「都市マップ素材」節に CC0 ライセンスの記載と公式サイト URL を追加
- ライセンスファイルの場所 (`public/images/city-kit/License.txt` など) を案内

## テスト結果
- `npm test` を実行し、既存テスト6件がすべて成功することを確認


------
https://chatgpt.com/codex/tasks/task_e_6860097b8694832cb7e424395ef6400e