### PR TITLE
スプライトマニフェスト自動生成スクリプト追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,12 @@ npm run unpack
 
 展開後、`public/tileManifest.js` で各画像を参照できるようになります。
 
+さらに以下のコマンドを実行すると、`tileManifest.js` と `spriteInfo.js` が自動生成されます。
+
+```bash
+npm run generate-manifest
+```
+
 主なディレクトリ構成例:
 
 ```
@@ -219,11 +225,13 @@ const spriteInfo = {
 };
 ```
 
-新しい画像を追加した場合は以下の手順で登録してください。
+新しい画像を追加したら、次のコマンドを実行するだけで `tileManifest.js` と `spriteInfo.js` が再生成されます。
 
-1. `public/images/sprites` に画像を配置し、`tileManifest.js` にパスを追記します。
-2. 同じキーを `spriteInfo.js` に追加し、`desc` に短い説明を書きます。
-3. `game_screen.html` などで `spriteInfo.js` が読み込まれているか確認します。
+```bash
+npm run generate-manifest
+```
+
+その後、`game_screen.html` などで `spriteInfo.js` が読み込まれているか確認してください。
 
 これにより、マップ生成時に使用タイルの一覧がコンソールへ表示され、選択ミスを防げます。
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "test": "jest",
     "start": "http-server public -p 8080",
-    "unpack": "node scripts/unpack_assets.js"
+    "unpack": "node scripts/unpack_assets.js",
+    "generate-manifest": "node scripts/generate_manifest.js"
   },
   "keywords": [],
   "author": "",

--- a/scripts/generate_manifest.js
+++ b/scripts/generate_manifest.js
@@ -1,0 +1,60 @@
+const fs = require('fs');
+const path = require('path');
+
+// 画像が置かれているディレクトリ
+const spritesDir = path.join(__dirname, '..', 'public', 'images', 'sprites');
+
+// 出力ファイル
+const manifestPath = path.join(__dirname, '..', 'public', 'tileManifest.js');
+const infoPath = path.join(__dirname, '..', 'public', 'spriteInfo.js');
+
+// ディレクトリを読み込み、PNG ファイル一覧を取得
+fs.readdir(spritesDir, (err, files) => {
+  if (err) {
+    console.error('sprites ディレクトリの読み込みに失敗しました:', err);
+    process.exit(1);
+  }
+
+  // PNG ファイルだけを対象とする
+  const pngFiles = files.filter((f) => f.toLowerCase().endsWith('.png'));
+
+  // tileManifest 用オブジェクト
+  const tileManifest = {};
+  // spriteInfo 用オブジェクト
+  const spriteInfo = {};
+
+  pngFiles.forEach((file) => {
+    // 拡張子を除いたファイル名をキーにする
+    const key = path.basename(file, '.png');
+    // ブラウザから参照する相対パス
+    const rel = path.posix.join('images', 'sprites', file);
+
+    tileManifest[key] = rel;
+
+    // 簡易説明を生成（建物系だけ推測、それ以外は空欄）
+    let desc = '';
+    if (key.startsWith('building-')) {
+      const suffix = key.replace('building-', '').toUpperCase();
+      desc = `建物${suffix}`;
+    }
+    spriteInfo[key] = { file: rel, desc };
+  });
+
+  // tileManifest.js の内容
+  const manifestContent = `// このファイルは scripts/generate_manifest.js により自動生成されました\n` +
+    `const tileManifest = ${JSON.stringify(tileManifest, null, 2)};\n\n` +
+    `if (typeof module !== 'undefined' && module.exports) {\n  module.exports = { tileManifest };\n}\n\n` +
+    `if (typeof window !== 'undefined') {\n  window.tileManifest = tileManifest;\n}\n`;
+
+  // spriteInfo.js の内容
+  const infoContent = `// このファイルは scripts/generate_manifest.js により自動生成されました\n` +
+    `const spriteInfo = ${JSON.stringify(spriteInfo, null, 2)};\n\n` +
+    `if (typeof module !== 'undefined' && module.exports) {\n  module.exports = { spriteInfo };\n}\n\n` +
+    `if (typeof window !== 'undefined') {\n  window.spriteInfo = spriteInfo;\n}\n`;
+
+  // ファイルへ書き込み
+  fs.writeFileSync(manifestPath, manifestContent, 'utf8');
+  fs.writeFileSync(infoPath, infoContent, 'utf8');
+
+  console.log('tileManifest.js と spriteInfo.js を生成しました');
+});


### PR DESCRIPTION
## 変更内容
- `scripts/generate_manifest.js` を追加し、`public/images/sprites` から `tileManifest.js` と `spriteInfo.js` を自動生成できるようにしました
- `package.json` に `generate-manifest` スクリプトを追加
- README に生成手順を追記

## 使い方
1. 画像を展開後、`npm run generate-manifest` を実行すると `public/tileManifest.js` と `public/spriteInfo.js` が更新されます
2. 生成されたファイルをブラウザで利用してください


------
https://chatgpt.com/codex/tasks/task_e_6861de1ea698832ca911663e3f46bcc8