### PR TITLE
calcNextStats 関数の削除

### DIFF
--- a/public/components/GameScreen.js
+++ b/public/components/GameScreen.js
@@ -85,17 +85,7 @@
   const prevStatsRef = useRef(stats);
   const [diffStats, setDiffStats] = useState({ cpi: 0, unemp: 0, gdp: 0, rate: 0 });
 
-  // -----------------------------
-  // 現在の指標と需給・金利から次ターンの指標を計算する補助関数
-  // -----------------------------
-  const calcNextStats = () => {
-    // updateEconomy 関数が利用可能か確認し、無ければ現在値を返す
-    if (typeof updateEconomy === 'function') {
-      return updateEconomy(stats, { demand, supply, policyRate });
-    }
-    return stats;
-  };
-
+  // 需要・供給・政策金利の状態を管理
   const [demand, setDemand] = useState(5);
   const [supply, setSupply] = useState(5);
   // 政策金利の初期値


### PR DESCRIPTION
## 概要
`GameScreen` コンポーネント内に未使用の `calcNextStats` 関数が残っていたため削除しました。これによりコードの見通しが良くなります。

## 主な変更点
- `public/components/GameScreen.js` から `calcNextStats` 定義を削除
- 需要・供給・政策金利の `useState` 付近を整理

## 使い方
`npm start` でローカルサーバーを起動し、ブラウザで `http://localhost:8080/index.html` にアクセスしてください。ゲーム画面では経済指標が定期的に更新されます。

## テスト
`npm test` を実行し、既存のテストスイートがすべて成功することを確認しました。

------
https://chatgpt.com/codex/tasks/task_e_6861e43bec8c832cbd4d31278b8a9181