### PR TITLE
コメント行の重複を整理

### DIFF
--- a/public/map_canvas.js
+++ b/public/map_canvas.js
@@ -110,7 +110,6 @@
   }
 
   // マップ全体を描画する関数
-  // マップ全体を描画する関数
   function drawMap(canvas, ctx, getImage) {
     // いったん画面をクリア
     ctx.clearRect(0, 0, canvas.width, canvas.height);


### PR DESCRIPTION
## 概要
`public/map_canvas.js` 内に重複していたコメントを1行にまとめました。動作確認として全テストを実行し、すべて成功することを確認しました。

## 変更内容
- `drawMap` 関数の宣言直前にあった同一コメント行の重複を削除

## 動作確認
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6861e52d79f8832ca93836c8cbfaac01