### PR TITLE
都心マップ生成ロジックと表示調整

### DIFF
--- a/public/components/GameScreen.js
+++ b/public/components/GameScreen.js
@@ -426,9 +426,9 @@
     // ヘッダーと指標表示の下にマップCanvasを配置する
     React.createElement('canvas', {
       id: 'mapCanvas',
-      // 高さ可変にするため flex-grow を付与し、幅いっぱいに広げる
-      // 背景色を付けず透過させる
-      className: 'flex-grow w-full border'
+      // 高さ可変にするため flex-grow を付与し、
+      // 背景色を付けず透過させる。境界線も付けない
+      className: 'flex-grow'
     }),
     activeIndicator
       ? React.createElement(IndicatorDetailModal, {

--- a/public/game_screen.css
+++ b/public/game_screen.css
@@ -130,9 +130,8 @@ body {
 
 /* マップ用キャンバスを親要素いっぱいに広げる */
 canvas#mapCanvas {
-  width: 100%;
-  height: 100%;
-  flex-grow: 1;
+  /* キャンバスサイズはスクリプト側で指定するため CSS では広げない */
+  image-rendering: pixelated;
 }
 
 

--- a/public/game_screen.html
+++ b/public/game_screen.html
@@ -38,7 +38,7 @@
   </header>
   <!-- マップ表示用キャンバス -->
   <!-- 背景色を無くし透過させる -->
-  <canvas id="mapCanvas" class="flex-grow w-full"></canvas>
+  <canvas id="mapCanvas" class="flex-grow"></canvas>
   <!-- ドロワー用のオーバーレイ -->
   <div id="drawerOverlay" class="fixed inset-0 bg-black/30"></div>
   <!-- サイドドロワー -->


### PR DESCRIPTION
## 概要
- マップタイルをランダム生成する処理を追加
- キャラクターのデフォルト色を黒に変更しサイズを10pxに固定
- タイルサイズを16pxに統一しCanvasのCSSも修正
- React版/HTML版ともにCanvasの境界線を廃止

## 使い方
`public/index.html` または `game_screen_react.html` を開くと
16pxタイルで生成された都心マップが表示されます。
矢印キーで黒いキャラクターを移動できます。

## テスト結果
- `npm test` 実行時、`jest` が見つからず失敗しました。
  環境に合わせて依存パッケージをインストールしてください。

------
https://chatgpt.com/codex/tasks/task_e_6861e78bc57c832c8e56901628ce2b3b