### PR TITLE
地面タイル用 manifest 追加

### DIFF
--- a/public/manifest.js
+++ b/public/manifest.js
@@ -1,0 +1,36 @@
+// 地面系タイルの一覧をまとめたファイル
+// tileManifest.js を先に読み込んでおく必要があります
+
+const groundTiles = {
+  // ベースとなるアスファルト
+  asphalt: {
+    key: 'tile_0001',
+    path: tileManifest['tile_0001'],
+    desc: 'アスファルト'
+  },
+  // 横方向の道路タイル
+  road: {
+    key: 'tile_0012',
+    path: tileManifest['tile_0012'],
+    desc: '道路（横）'
+  },
+  // 公園などに使える芝生
+  grass: {
+    key: 'tile_0033',
+    path: tileManifest['tile_0033'],
+    desc: '芝生'
+  },
+  // 歩行者用の横断歩道
+  crosswalk: {
+    key: 'tile_0040',
+    path: tileManifest['tile_0040'],
+    desc: '横断歩道'
+  }
+};
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { groundTiles };
+}
+if (typeof window !== 'undefined') {
+  window.groundTiles = groundTiles;
+}


### PR DESCRIPTION
## 変更点
- 地面系タイルをまとめた `public/manifest.js` を新規作成しました
- アスファルト・道路・芝生・横断歩道の4種類を分類しています

## 使い方
`tileManifest.js` を読み込んだあとに `manifest.js` を読み込むことで、`groundTiles` オブジェクトから各タイルのキーや画像パスを取得できます。

## テスト
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686528f40abc832c8494d04cb5e87be3