### PR TITLE
経済カードのデザインを ECOBOX と統一

### DIFF
--- a/public/EconomicCard.jsx
+++ b/public/EconomicCard.jsx
@@ -21,7 +21,8 @@ const EconomicCard = () => {
 
   return (
     // ECOBOX と同じダーク系のデザインに変更
-    <div className="p-4 bg-gradient-to-b from-slate-800 to-slate-700 text-white rounded-xl shadow-md border border-slate-600 w-full max-w-md">
+    // アクセントとして境界線に cyan 系の色を追加
+    <div className="p-4 font-sans bg-gradient-to-b from-slate-800 to-slate-700 text-white rounded-xl shadow-md border-2 border-cyan-400 w-full max-w-md">
       {/* タイトル */}
       <p className="text-sm font-bold mb-2">CPI（消費者物価指数）</p>
       {/* スパークラインと使い方メモ */}

--- a/public/economic_card.html
+++ b/public/economic_card.html
@@ -6,7 +6,8 @@
   <title>経済カード例</title>
   <!-- Tailwind CSS CDN -->
   <script src="https://cdn.tailwindcss.com"></script>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=Noto+Sans+JP:wght@100..900&display=swap" rel="stylesheet">
+  <!-- Noto Sans JP のみを読み込み、ECOBOX と同じフォントを使用 -->
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@100..900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="globals.css">
   <!-- React と ReactDOM (ローカル) -->
   <script src="libs/react.development.js"></script>
@@ -19,7 +20,7 @@
   <script type="text/babel" src="SparkChart.jsx"></script>
   <script type="text/babel" src="EconomicCard.jsx"></script>
 </head>
-<body class="bg-gray-100 flex items-center justify-center h-screen">
+<body class="bg-gray-100 flex items-center justify-center h-screen font-sans">
   <div id="root"></div>
   <script type="text/babel">
     // EconomicCardコンポーネントを画面に描画


### PR DESCRIPTION
### 変更内容
- 経済カードに cyan 系のボーダーを追加し ECOBOX と同じダークテーマに調整
- フォントを `Noto Sans JP` に統一

### 動作確認
- `npm test` を実行し全てのテストが成功することを確認


------
https://chatgpt.com/codex/tasks/task_e_686667d1fd1c832c86ddfec18b8ffa93