### PR TITLE
スパークラインのホバー表示削除

### DIFF
--- a/public/components/Sparkline.js
+++ b/public/components/Sparkline.js
@@ -83,11 +83,6 @@
       React.createElement('text', { x: size.w - 24, y: size.h - 2, fontSize: '10', fill: '#555' }, '時間'),
       hoverInfo && React.createElement('circle', { r: 4, className: 'sparkline-dot', style: { transform: `translate(${hoverInfo.x}px, ${hoverInfo.y}px)` } })
     ),
-    hoverInfo && React.createElement(
-      'div',
-      { className: 'sparkline-tooltip', style: { left: `${hoverInfo.x}px` } },
-      history[hoverInfo.index].toFixed(1)
-    ),
     React.createElement(
       'div',
       { className: 'sparkline-stats flex justify-between text-xs text-gray-500 mt-1' },

--- a/public/game_screen.css
+++ b/public/game_screen.css
@@ -78,18 +78,6 @@ body {
   display: block;
 }
 
-/* ホバーした位置の値を表示するツールチップ */
-.sparkline-tooltip {
-  position: absolute;
-  transform: translate(-50%, -4px);
-  background: rgba(255, 255, 255, 0.9);
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  font-size: 0.75rem; /* text-xs */
-  padding: 2px 4px;
-  pointer-events: none;
-  white-space: nowrap;
-}
 
 /* ホバー位置を示す点 */
 .sparkline-dot {


### PR DESCRIPTION
## 変更内容
- Sparkline.js からツールチップ生成処理を削除
- game_screen.css からツールチップ用スタイルを削除

## テスト
- `npm install`
- `npm test` を実行し全テストが成功することを確認

------
https://chatgpt.com/codex/tasks/task_e_686697905130832cb541c7ff5bf2bc98